### PR TITLE
automatically run `regenerate_filters.sh` on pull request

### DIFF
--- a/.github/workflows/generate_links.sh
+++ b/.github/workflows/generate_links.sh
@@ -1,0 +1,23 @@
+on:
+  pull_request:
+    paths:
+      - 'PLAIN_LIST'
+      - 'regenerate_filters.sh'
+
+jobs:
+  generate_links:
+    runs-on: ubuntu-latest
+    permissions:
+      # Give the default GITHUB_TOKEN write permission to commit and push the changed files back to the repository.
+      contents: write
+    steps:
+    - uses: actions/checkout@v3
+    - run: |
+        chmod +x ./regenerate_filters.sh
+        ./regenerate_filters.sh
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+    - uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        commit_message: Updated `LIST`
+        file_pattern: LIST

--- a/README.md
+++ b/README.md
@@ -15,8 +15,10 @@ There's also the [PLAIN_LIST](https://github.com/LiamDawe/steamdeck_spamblock/bl
 # Contributing
 
 * To have a site accepted in a pull request, please list examples of their spamminess.
-* Please add the site to the PLAIN_LIST as well in your PR.
-* If able, please run the `./regenerate_filters.sh` script to update the LIST file with filters for the newly added site.
+* Please add the site to the `PLAIN_LIST` as well in your PR.
+* Please don't edit the `LIST` file manualy, as it is automaticaly generated.
+* If tou know what you are doing, edit `regenerate_filters.sh
+` to add new search engine
 
 # What Search Engines Are Accepted?
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ There's also the [PLAIN_LIST](https://github.com/LiamDawe/steamdeck_spamblock/bl
 
 * To have a site accepted in a pull request, please list examples of their spamminess.
 * Please add the site to the `PLAIN_LIST` as well in your PR.
-* Please don't edit the `LIST` file manualy, as it is automaticaly generated.
-* If tou know what you are doing, edit `regenerate_filters.sh
+* Please don't edit the `LIST` file manualy, as it is automatically generated.
+* If you know what you are doing, edit `regenerate_filters.sh
 ` to add new search engine
 
 # What Search Engines Are Accepted?


### PR DESCRIPTION
Hi Liam,

I just wanted to automatized your repo slightly, for your nice project.

It will generate the `LIST` file whenever the `PLAN_LIST` or `regenerate_filters.sh` (to add new search engine) is modified on a pull request.